### PR TITLE
Bug fix for node image v.0.0.3

### DIFF
--- a/cmd/local-resource-manager/main.go
+++ b/cmd/local-resource-manager/main.go
@@ -53,8 +53,10 @@ func main() {
 	flag.StringVar(&flags.ResourceType, "resources-types", "k8s-fluidos", "Type of the Flavour related to k8s resources")
 	flag.StringVar(&flags.CPUMin, "cpu-min", "0", "Minimum CPU value")
 	flag.StringVar(&flags.MemoryMin, "memory-min", "0", "Minimum memory value")
+	flag.StringVar(&flags.PodsMin, "pods-min", "0", "Minimum Pods value")
 	flag.StringVar(&flags.CPUStep, "cpu-step", "0", "CPU step value")
 	flag.StringVar(&flags.MemoryStep, "memory-step", "0", "Memory step value")
+	flag.StringVar(&flags.PodsStep, "pods-step", "0", "Pods step value")
 	flag.Int64Var(&flags.MinCount, "min-count", 0, "Minimum number of flavours")
 	flag.Int64Var(&flags.MaxCount, "max-count", 0, "Maximum number of flavours")
 	flag.StringVar(&flags.ResourceNodeLabel, "node-resource-label", "node-role.fluidos.eu/resources",

--- a/pkg/utils/resourceforge/forge.go
+++ b/pkg/utils/resourceforge/forge.go
@@ -177,6 +177,7 @@ func ForgeFlavourFromMetrics(node *models.NodeInfo, ni nodecorev1alpha1.NodeIden
 					PodsMin:    parseutil.ParseQuantityFromString(flags.PodsMin),
 					CpuStep:    parseutil.ParseQuantityFromString(flags.CPUStep),
 					MemoryStep: parseutil.ParseQuantityFromString(flags.MemoryStep),
+					PodsStep:   parseutil.ParseQuantityFromString(flags.PodsStep),
 				},
 				Aggregatable: &nodecorev1alpha1.Aggregatable{
 					MinCount: int(flags.MinCount),


### PR DESCRIPTION
Hello everyone.

This PR is due to a bug fix regarding the Flavors creation done by the LRM (Local Resource Manager).

The steps performed are the following:

1. Added missing info: **PodsStep** field into **Policy** object when using `ForgeFlavourFromMetrics` function in` /pkg/utils/resourceforce/forge.go`
2. Added missing flags into LRM main: **PodsMin** and **PodsStep**

This should solve possible running issues when scheduling LRM pods into a Kubernetes cluster.

Regards,
Francesco