### PR TITLE
Correction on multiple Solver CRs creation

### DIFF
--- a/pkg/rear-controller/contract-manager/reservation_controller.go
+++ b/pkg/rear-controller/contract-manager/reservation_controller.go
@@ -163,6 +163,7 @@ func (r *ReservationReconciler) handleReserve(ctx context.Context,
 
 		// Set the peering candidate as not available
 		peeringCandidate.Spec.Available = false
+		peeringCandidate.Spec.SolverID = reservation.Spec.SolverID
 		if err := r.Update(ctx, peeringCandidate); err != nil {
 			klog.Errorf("Error when updating PeeringCandidate %s status before reconcile: %s", req.NamespacedName, err)
 			return ctrl.Result{}, err
@@ -185,6 +186,7 @@ func (r *ReservationReconciler) handleReserve(ctx context.Context,
 
 			// Set the peering candidate as available again
 			peeringCandidate.Spec.Available = true
+			peeringCandidate.Spec.SolverID = ""
 			if err := r.Update(ctx, peeringCandidate); err != nil {
 				klog.Errorf("Error when updating PeeringCandidate %s status before reconcile: %s", req.NamespacedName, err)
 				return ctrl.Result{}, err
@@ -299,6 +301,7 @@ func (r *ReservationReconciler) handlePurchase(ctx context.Context,
 			}
 
 			peeringCandidate.Spec.Available = true
+			peeringCandidate.Spec.SolverID = ""
 			if err := r.Update(ctx, &peeringCandidate); err != nil {
 				klog.Errorf("Error when updating PeeringCandidate %s status before reconcile: %s", req.NamespacedName, err)
 				return ctrl.Result{}, err


### PR DESCRIPTION
Hello everyone.

This PR resolves #29 and #62.

I found the logic of PeeringCandidate reservation scattered across different controllers which prevented the correct execution of the FLUIDOS Node in case of dealing with more than one solver.

Moreover, there was also  missed a logic which would re-assign an already available PeeringCandidate that has not been previously reserved to a new Solver CR.
This is needed for correctly execute multiple Solvers using the same PeeringCandidate table with the current implementation.

Looking forward to receiving any feedback.

Thanks,
Francesco