### PR TITLE
Remove Solved Status check into Solver Controller

### DIFF
--- a/pkg/rear-manager/solver_controller.go
+++ b/pkg/rear-manager/solver_controller.go
@@ -108,8 +108,7 @@ func (r *SolverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Check if the Solver has expired or failed, in this case do nothing and return
 	if solver.Status.SolverPhase.Phase == nodecorev1alpha1.PhaseFailed ||
-		solver.Status.SolverPhase.Phase == nodecorev1alpha1.PhaseTimeout ||
-		solver.Status.SolverPhase.Phase == nodecorev1alpha1.PhaseSolved {
+		solver.Status.SolverPhase.Phase == nodecorev1alpha1.PhaseTimeout {
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Hi folks.

This PR resolves #57 and  #68.

This modifications should avoid interrupring the Solver Controller execution before checking Spec modifications, allowing external Sovler CR's modifications to be applied.

However, a future redesign of the Solver CRD Status could be needed.

Regards,
Francesco