### PR TITLE
fix: Adjusting reservation creation if PeeringCandidates available within the cluster

### DIFF
--- a/pkg/rear-manager/solver_controller.go
+++ b/pkg/rear-manager/solver_controller.go
@@ -124,11 +124,11 @@ func (r *SolverReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			klog.Errorf("Error when updating Solver %s status: %s", req.NamespacedName, err)
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
 	}
 
 	if solver.Spec.ReserveAndBuy {
-		if findCandidateStatus == nodecorev1alpha1.PhaseSolved && reserveAndBuyStatus != nodecorev1alpha1.PhaseSolved {
+		if (findCandidateStatus == nodecorev1alpha1.PhaseSolved || !solver.Spec.FindCandidate) &&
+			reserveAndBuyStatus != nodecorev1alpha1.PhaseSolved {
 			return r.handleReserveAndBuy(ctx, req, &solver)
 		}
 	} else {


### PR DESCRIPTION
Hello folks.

This PR resolves #70

This bug fix solves the misbehviour of the architecture.

 It is now possible to put the findCandidate boolean flag to false when creating Solver CRs.
 
 If there are PeeringCanddiate suitable to fulfill the request and a Reservation object is created and linked to this Solver, the Reservation phase succeeds.
 
 Regards,
 Francesco