### PR TITLE
Adding new installation process documentation

### DIFF
--- a/deployments/node/README.md
+++ b/deployments/node/README.md
@@ -38,7 +38,6 @@ A Helm chart for Fluidos Node
 | networkManager.pod.labels | object | `{}` | Labels for the network-manager pod. |
 | networkManager.pod.resources | object | `{"limits":{},"requests":{}}` | Resource requests and limits (https://kubernetes.io/docs/user-guide/compute-resources/) for the network-manager pod. |
 | networkManager.replicas | int | `1` | The number of Network Manager, which can be increased for active/passive high availability. |
-| provider | string | `"your-provider"` |  |
 | pullPolicy | string | `"IfNotPresent"` | The pullPolicy for fluidos-node pods. |
 | rearController.imageName | string | `"ghcr.io/fluidos-project/rear-controller"` |  |
 | rearController.pod.annotations | object | `{}` | Annotations for the rear-controller pod. |

--- a/deployments/node/templates/fluidos-pre-install-hook-cm.yaml
+++ b/deployments/node/templates/fluidos-pre-install-hook-cm.yaml
@@ -52,27 +52,27 @@ data:
     }
 
     # Function to install liqo if not installed
-    install_liqo() {
-        local provider=$1
+    # install_liqo() {
+    #     local provider=$1
 
-        if [ -z "$provider" ]; then
-            echo "Provider not specified for liqo. Usage: $0 <provider>"
-            exit 1
-        fi
+    #     if [ -z "$provider" ]; then
+    #         echo "Provider not specified for liqo. Usage: $0 <provider>"
+    #         exit 1
+    #     fi
 
-        if ! is_helm_installed "default" "liqo" && ! is_k8s_resource_present "deployment/liqo" "liqo"; then
-            echo "Installing liqo with provider $provider..."
-            curl -sL https://github.com/liqotech/liqo/releases/download/v0.4.0/liqoctl-linux-amd64 -o /usr/local/bin/liqoctl
-            chmod +x /usr/local/bin/liqoctl
-            liqoctl install $provider --cluster-name $provider --only-output-values --dump-values-path="values-liqo.yaml"
-            helm repo add liqo https://helm.liqo.io/
-            helm repo update
-            helm install liqo liqo/liqo -f values-liqo.yaml -n liqo --set discovery.config.enableAdvertisement=false --create-namespace --kubeconfig "$KUBECONFIG"
-            rm values-liqo.yaml
-        else
-            echo "liqo is already installed."
-        fi
-    }
+    #     if ! is_helm_installed "default" "liqo" && ! is_k8s_resource_present "deployment/liqo" "liqo"; then
+    #         echo "Installing liqo with provider $provider..."
+    #         curl -sL https://github.com/liqotech/liqo/releases/download/v0.4.0/liqoctl-linux-amd64 -o /usr/local/bin/liqoctl
+    #         chmod +x /usr/local/bin/liqoctl
+    #         liqoctl install $provider --cluster-name $provider --only-output-values --dump-values-path="values-liqo.yaml"
+    #         helm repo add liqo https://helm.liqo.io/
+    #         helm repo update
+    #         helm install liqo liqo/liqo -f values-liqo.yaml -n liqo --set discovery.config.enableAdvertisement=false --create-namespace --kubeconfig "$KUBECONFIG"
+    #         rm values-liqo.yaml
+    #     else
+    #         echo "liqo is already installed."
+    #     fi
+    # }
 
     # Main script
     main() {

--- a/deployments/node/values.yaml
+++ b/deployments/node/values.yaml
@@ -148,4 +148,4 @@ networkManager:
       # -- The NodeID is a UUID that identifies the FLUIDOS Node. It is used to generate the FQDN of the owned FLUIDOS Nodes and it is unique in the FLUIDOS closed domain
       nodeID: 
 
-provider: "your-provider"
+# provider: "your-provider"

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -1,14 +1,28 @@
 # Installation
 
-A quick script for installing the FLUIDOS Node is available. Currently, the script supports installation on KIND Clusters, with plans to extend support to generic Kubernetes clusters in the near future.
+This section shows the installation process of the FLUIDOS Node components.
 
----
+There are two ways to install FLUIDOS Node components:
 
+1. Launching the testbed environment with a script.
+
+2. Installing the FLUIDOS Node manually on your Kubernetes cluster.
+
+If it's your first time with FLUIDOS Node components, we suggest the testbed environment via script. This allows you to install as many kind clusters as you want to run your experiments.
+
+However, if you want to test FLUIDOS Node on your cluster already setup, we suggest you the manual installation.
+
+<!-- A quick script for installing the FLUIDOS Node is available. Currently, the script supports installation on KIND Clusters, with plans to extend support to generic Kubernetes clusters in the near future. -->
+
+<!-- --- -->
+<!-- 
 **⚠️ ATTENTION:** The script is currently in an experimental phase, so it may not work as expected. If any issues arise, it may be tricky to understand and terminate the script, as many sub-tasks are executed in the background. We are aware of these issues and are actively working to resolve them.
 
-If you want to use a **working and tested script** to test the FLUIDOS Node within a KinD environment, please refer to the [**Testbed**](../../testbed/kind/README.md) section.
+If you want to use a **working and tested script** to test the FLUIDOS Node within a KinD environment, please refer to the [**Testbed**](../../testbed/kind/README.md) section. -->
 
----
+<!-- --- -->
+
+## Testbed installation
 
 To execute the script, use the following command:
 
@@ -21,19 +35,72 @@ No options are available through the CLI, but you can choose the installation mo
 The option supported are:
 
 - `1` to install the FLUIDOS Node as the demo testbed through KIND
+
 - `2` to install the FLUIDOS Node in n consumer clusters and m provider clusters through KIND
-- `3` to install the FLUIDOS Node in n clusters through their KUBECONFIG files
-  **DISCLAIMER:** in this case all your Kubernetes clusters inserted in the script must have at least one node tagged with `node-role.fluidos.eu/worker: "true"` and at least in the provider clusters, you can choose the nodes that exposes their Kubernetes resources with the label `node-role.fluidos.eu/resources: "true"`.
 
-For each option, you can choose to install from either the official remote FLUIDOS repository or the local repository, by building it at the moment.
+For both options, you can choose to install from either the official remote FLUIDOS repository or the local repository, building all the components locally.
 
-## Clean Development Environment
+### Clean Development Environment
 
-If you installed FLUIDOS Node on kind clusters and want to clean up the entire environment setup, run the following commands:
+If you installed FLUIDOS Node on kind clusters and want to clean up the entire testbed setup, run the following commands:
 
 ```bash
-cd tools/scripts
-. ./clean-dev-env.sh
+cd ../../tools/scripts
+./clean-dev-env.sh
 ```
 
 This script will delete both the kind clusters and their corresponding kubeconfig files.
+
+## Manual installation
+
+Please, make sure you have [helm](https://helm.sh/docs/intro/install/) installed.
+
+To install the FLUIDOS Node on your Kubernetes cluster already up and running, you must ensure you have [Liqo](https://liqo.io/) up and running.
+
+If you are not sure you already have Liqo on your Kubernetes cluster, we suggest to check the next sub-section.
+
+### Install Liqo on your Kubernetes cluster
+
+To ensure you have Liqo, please run the following script:
+
+```bash
+cd ../../tools/scripts
+./install-liqo.sh <provider> <cluster-name> $KUBECONFIG
+```
+
+Please, note that you need to pass a few parameters.
+
+- "provider": this parameter depends on your Kubernetes installation.
+    We currently test it on the following providers:
+      1. kubeadm
+      2. k3s
+      3. kind
+- "cluster-name": this is the name you want to give to your Liqo local cluster (e.g.: `fluidos-turin-1`)
+
+- $KUBECONFIG: it is the typical environment variable that points to the path of your Kubernetes cluster configuration.
+
+For more information, check out [Liqo official documentation](https://docs.liqo.io/en/v0.10.3/installation/install.html#install-with-liqoctl) for all supported providers.
+
+**DISCLAIMER:** before going ahead, ensure that at least one node is tagged with `node-role.fluidos.eu/worker: "true"` and, if acting as a provider, choose the nodes that exposes their Kubernetes resources with the label `node-role.fluidos.eu/resources: "true"`.
+
+Once we have Liqo running, we can install the FLUIDOS Node component via helm:
+
+```bash
+helm repo add fluidos https://fluidos-project.github.io/node/
+
+
+helm install node fluidos/node -n fluidos \
+--create-namespace -f ../../quickstart/utils/consumer-values.yaml \
+--set networkManager.configMaps.nodeIdentity.ip="LOCAL_K8S_CLUSTER_CP_IP:LOCAL_REAR_PORT"\
+--set networkManager.configMaps.providers.local="REMOTE_K8S_CLUSTER_CP_IP:REMOTE_REAR_PORT"\
+--wait 
+```
+
+Due to the absence of the Network Manager component that enable the auto-discovery among FLUIDOS Nodes, we need to setup some parameters manually to allow Nodes discovery.
+
+Here, the meaning of the various parameters:
+
+- LOCAL_K8S_CLUSTER_CP_IP: The IP address of your local Kubernetes cluster Control Plane
+- LOCAL_REAR_PORT: The port on which your local cluster uses the REAR protocol
+- REMOTE_K8S_CLUSTER_CP_IP: It's the IP address of the remote Kubernetes cluster to which you want to negotiate Flavors thorugh REAR with.
+- REMOTE_REAR_PORT: It's the port on which the remote cluster uses the REAR protocol.

--- a/tools/scripts/install_liqo.sh
+++ b/tools/scripts/install_liqo.sh
@@ -22,14 +22,17 @@ fi
 check_and_install_liqoctl
 
 # Get the provider parameter
+# Get the provider parameter
 PROVIDER=$1
 
-control_plane_node=$(kubectl get nodes -l node-role.kubernetes.io/control-plane -o jsonpath='{.items[0].metadata.name}')
-cluster_name=${control_plane_node%-control-plane}
+# Get the cluster name
+CLUSTER_NAME=$2
 
+# Get the Kubeconfig
+KUBECONFIG_LIQO=$3
 
 # Install Liqo based on the provider
-liqoctl install "$PROVIDER" --cluster-name "$cluster_name" || { echo "Failed to install Liqo for provider: $PROVIDER"; exit 1; }
+liqoctl install "$PROVIDER" --cluster-name "$CLUSTER_NAME" --kubeconfig "$KUBECONFIG_LIQO" || { echo "Failed to install Liqo for provider: $PROVIDER"; exit 1; }
 # liqoctl install "$PROVIDER" || { echo "Failed to install Liqo for provider: $PROVIDER"; exit 1; }
 
 echo "Liqo installation for provider $PROVIDER completed successfully."

--- a/tools/scripts/installation.sh
+++ b/tools/scripts/installation.sh
@@ -208,7 +208,7 @@ function install_components() {
 
         # Install liqo
         chmod +x "$SCRIPT_DIR"/install_liqo.sh
-        "$SCRIPT_DIR"/install_liqo.sh "$installation_type" || { echo "Failed to install Liqo in cluster $cluster"; exit 1; }
+                "$SCRIPT_DIR"/install_liqo.sh "$installation_type" "$cluster" "$KUBECONFIG"  || { echo "Failed to install Liqo in cluster $cluster"; exit 1; }
         chmod -x "$SCRIPT_DIR"/install_liqo.sh
 
         # Skipping the installation of the node Helm chart if the cluster is a provider and its installation type is not kind

--- a/tools/scripts/setup.sh
+++ b/tools/scripts/setup.sh
@@ -41,7 +41,6 @@ echo "We'll now run the installation process for the FLUIDOS node."
 read -r -p "What type of environment do you want to use? /
 1. Use demo KIND environment (one consumer and one provider) /
 2. Use a custom KIND environment with n consumer and m provides /
-3. Use personal Kubernetes clusters through KUBECONFIG files /
 Please enter the number of the option you want to use:
  " environment_type
 
@@ -111,22 +110,22 @@ elif [ "$environment_type" -eq 2 ]; then
 
     # Call create_kind clusters with parameters and save return value into clusters variable
     create_kind_clusters "$consumers_json" "$providers_json" $environment_type "$consumer_clusters" "$provider_clusters" 
-elif [ "$environment_type" -eq 3 ]; then
-    # Ask the user what Kubernetes clusters they want to use between kubeadm and k3s
-    read -r -p "What type of Kubernetes clusters do you want to use? 
-    1. kubeadm 
-    2. k3s 
-    Please enter the number of the option you want to use:
-    " installation_type
-    if [ "$installation_type" -eq 1 ]; then
-        installation_type="kubeadm"
-    elif [ "$installation_type" -eq 2 ]; then
-        installation_type="k3s"
-    else
-        echo "Invalid option."
-        return 1
-    fi
-    get_clusters "$consumers_json" "$providers_json"
+# elif [ "$environment_type" -eq 3 ]; then
+#     # Ask the user what Kubernetes clusters they want to use between kubeadm and k3s
+#     read -r -p "What type of Kubernetes clusters do you want to use? 
+#     1. kubeadm 
+#     2. k3s 
+#     Please enter the number of the option you want to use:
+#     " installation_type
+#     if [ "$installation_type" -eq 1 ]; then
+#         installation_type="kubeadm"
+#     elif [ "$installation_type" -eq 2 ]; then
+#         installation_type="k3s"
+#     else
+#         echo "Invalid option."
+#         return 1
+#     fi
+#     get_clusters "$consumers_json" "$providers_json"
 else
     echo "Invalid option."
     return 1


### PR DESCRIPTION
Hi everyone-

This PR resovles #94 ..

More specifically, the installation process has been divided into two sections:
1. Installation of the testbed of FLUIDOS Node running on kind clusters.
2. Manual installation of FLUIDOS Node on a Kubernetes cluster up and running.

Regards,
Francesco