### PR TITLE
Adjusting peering allocation phase

### DIFF
--- a/deployments/node/samples/allocation.yaml
+++ b/deployments/node/samples/allocation.yaml
@@ -10,3 +10,4 @@ spec:
   contract:
     name: contract-fluidos.eu-k8slice-7413576d05fe8e93c719e13eab156c5c-ae7e
     namespace: fluidos
+    

--- a/deployments/node/samples/reservation.yaml
+++ b/deployments/node/samples/reservation.yaml
@@ -1,7 +1,7 @@
 apiVersion: reservation.fluidos.eu/v1alpha1
 kind: Reservation
 metadata:
-  name: reservation-solver-sample-2
+  name: reservation-solver-sample
   namespace: fluidos
 spec:
   solverID: solver-sample-2
@@ -17,7 +17,7 @@ spec:
       pods: "110"
   # Retrieve from PeeringCandidate chosen to reserve
   peeringCandidate:
-    name: peeringcandidate-fluidos.eu-k8slice-7413576d05fe8e93c719e13eab156c5c
+    name: peeringcandidate-fluidos.eu-k8slice-0e682ec3133811bb0d52b6373c339f81
     namespace: fluidos
   # Set it to reserve
   reserve: true
@@ -26,10 +26,11 @@ spec:
   # Retrieve from PeeringCandidate Flavor Owner field    
   seller:
     domain: fluidos.eu
-    ip: 172.19.0.2:30001
-    nodeID: ejbbzmacn0
+    ip: 172.19.0.4:30001
+    nodeID: 4ahrqttvng
   # Retrieve from configmap
   buyer:
     domain: fluidos.eu
     ip: 172.19.0.5:30000
-    nodeID: e9d2mzsbcf
+    nodeID: rd5ks7x9yz
+    

--- a/deployments/node/samples/solver.yaml
+++ b/deployments/node/samples/solver.yaml
@@ -1,7 +1,7 @@
 apiVersion: nodecore.fluidos.eu/v1alpha1
 kind: Solver
 metadata:
-  name: solver-sample-3
+  name: solver-sample
   namespace: fluidos
 spec:
   # This is the Selector used to find a Flavor (FLUIDOS node) that matches the requirements
@@ -37,7 +37,7 @@ spec:
         data:
           value: 110
   # The intentID is the ID of the intent that the solver should satisfy
-  intentID: "intent-sample-3"
+  intentID: "intent-sample"
   # This flag is used to indicate that the solver should find a candidate (FLUIDOS node)
   findCandidate: true
   # This flag is used to indicate that the solver should reserve and buy the resources from the candidate (FLUIDOS node)


### PR DESCRIPTION
Hi folks.

This PR resolves #110 

The FLUIDOS Node consumer now avoids to re-establish a peering session with a foreign cluster already peered.

Bye,
Francesco