### PR TITLE
Bumped linting to go 1.23 e golangci-lint to 1.60

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,14 +17,14 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.23"
           cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           only-new-issues: true
-          version: v1.54.2
+          version: v1.60
           args: --timeout=900s
 
   gomodtidy:


### PR DESCRIPTION
Hi,

This PR is intended to upgrade the CI pipeline of GitHub to Go version 1.23 e golangci-lint to version 1.60.

This change is necessary for further upgrades both in node code and its dependencies.

Thank you!

Andrea