### PR TITLE
Bump linting to go v1.24 and to golangci-lint v1.64.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,21 +10,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          #ref: ${{ github.event.pull_request.head.sha }}
+          #repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           only-new-issues: true
-          version: v1.60
+          version: v1.64.2
           args: --timeout=900s
 
   gomodtidy:
@@ -35,14 +35,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event.pull_request.head.sha }}"
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          #ref: "${{ github.event.pull_request.head.sha }}"
+          #repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.24"
 
       - name: Execute go mod tidy and check the outcome
         working-directory: ./
@@ -54,7 +54,8 @@ jobs:
       - name: Issue a comment in case the of failure
         uses: peter-evans/create-or-update-comment@v3
         with:
-          token: ${{ secrets.CI_TOKEN }}
+          #token: ${{ secrets.CI_TOKEN }}
+          token: "dummy"
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             The `go.mod` and/or `go.sum` files appear not to be correctly tidied.
@@ -71,8 +72,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event.pull_request.head.sha }}"
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          #ref: "${{ github.event.pull_request.head.sha }}"
+          #repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
       - name: Run Shellcheck
         uses: ludeeus/action-shellcheck@2.0.0
@@ -87,8 +88,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event.pull_request.head.sha }}"
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          #ref: "${{ github.event.pull_request.head.sha }}"
+          #repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
       - name: Lint markdown files
         uses: avto-dev/markdown-lint@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,8 +10,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          #ref: ${{ github.event.pull_request.head.sha }}
-          #repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Setup Go
@@ -35,8 +35,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          #ref: "${{ github.event.pull_request.head.sha }}"
-          #repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: "${{ github.event.pull_request.head.sha }}"
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Setup Go
@@ -54,8 +54,7 @@ jobs:
       - name: Issue a comment in case the of failure
         uses: peter-evans/create-or-update-comment@v3
         with:
-          #token: ${{ secrets.CI_TOKEN }}
-          token: "dummy"
+          token: ${{ secrets.CI_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             The `go.mod` and/or `go.sum` files appear not to be correctly tidied.
@@ -72,8 +71,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          #ref: "${{ github.event.pull_request.head.sha }}"
-          #repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: "${{ github.event.pull_request.head.sha }}"
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
       - name: Run Shellcheck
         uses: ludeeus/action-shellcheck@2.0.0
@@ -88,8 +87,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          #ref: "${{ github.event.pull_request.head.sha }}"
-          #repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: "${{ github.event.pull_request.head.sha }}"
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
       - name: Lint markdown files
         uses: avto-dev/markdown-lint@v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,5 @@
 run:
   timeout: 10m
-  skip-files:
-    - "zz_generated.*.go"
-    - "consts.go"
-  skip-dirs:
-    - "pkg/client"
 
 linters-settings:
   exhaustive:
@@ -45,7 +40,7 @@ linters-settings:
       - prefix(github.com/fluidos-project/node) # Groups all imports with the specified Prefix.
   goconst:
     min-len: 2
-    min-occurrences: 2
+    min-occurrences: 3
   gocritic:
     enabled-tags:
       - diagnostic
@@ -59,7 +54,7 @@ linters-settings:
   goimports:
     local-prefixes: github.com/fluidos-project/node
   govet:
-    check-shadowing: true
+    shadow: true
   misspell:
     locale: US
     ignore-words:
@@ -72,6 +67,8 @@ linters-settings:
     require-specific: true # require nolint directives to be specific about which linter is being skipped
   dupl:
     threshold: 300
+  gocyclo:
+    min-complexity: 34
 
 linters:
   disable-all: true
@@ -84,7 +81,7 @@ linters:
     - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     # - funlen
     # - gochecknoglobals
     # - gochecknoinits
@@ -128,6 +125,12 @@ linters:
 
 issues:
   #fix: true
+
+  exclude-files:
+    - "zz_generated.*.go"
+    - "consts.go"
+  exclude-dirs:
+    - "pkg/client"
 
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/apis/advertisement/v1alpha1/discovery_status.go
+++ b/apis/advertisement/v1alpha1/discovery_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/advertisement/v1alpha1/discovery_types.go
+++ b/apis/advertisement/v1alpha1/discovery_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/advertisement/v1alpha1/groupversion_info.go
+++ b/apis/advertisement/v1alpha1/groupversion_info.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/advertisement/v1alpha1/peeringcandidate_types.go
+++ b/apis/advertisement/v1alpha1/peeringcandidate_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/network/v1alpha1/groupversion_info.go
+++ b/apis/network/v1alpha1/groupversion_info.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/network/v1alpha1/knowncluster_status.go
+++ b/apis/network/v1alpha1/knowncluster_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/network/v1alpha1/knowncluster_types.go
+++ b/apis/network/v1alpha1/knowncluster_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/allocation_status.go
+++ b/apis/nodecore/v1alpha1/allocation_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/allocation_types.go
+++ b/apis/nodecore/v1alpha1/allocation_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/common.go
+++ b/apis/nodecore/v1alpha1/common.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/flavor_types.go
+++ b/apis/nodecore/v1alpha1/flavor_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/flavor_types_common.go
+++ b/apis/nodecore/v1alpha1/flavor_types_common.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/flavor_webhook.go
+++ b/apis/nodecore/v1alpha1/flavor_webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/groupversion_info.go
+++ b/apis/nodecore/v1alpha1/groupversion_info.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/k8slice_configuration.go
+++ b/apis/nodecore/v1alpha1/k8slice_configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/k8slice_flavor.go
+++ b/apis/nodecore/v1alpha1/k8slice_flavor.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/k8slice_selector.go
+++ b/apis/nodecore/v1alpha1/k8slice_selector.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/network_intent.go
+++ b/apis/nodecore/v1alpha1/network_intent.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/selector.go
+++ b/apis/nodecore/v1alpha1/selector.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/sensor_flavor.go
+++ b/apis/nodecore/v1alpha1/sensor_flavor.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/service_blueprint.go
+++ b/apis/nodecore/v1alpha1/service_blueprint.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/service_blueprint_webhook.go
+++ b/apis/nodecore/v1alpha1/service_blueprint_webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/service_configuration.go
+++ b/apis/nodecore/v1alpha1/service_configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/service_flavor.go
+++ b/apis/nodecore/v1alpha1/service_flavor.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/service_selector.go
+++ b/apis/nodecore/v1alpha1/service_selector.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/solver_status.go
+++ b/apis/nodecore/v1alpha1/solver_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/solver_types.go
+++ b/apis/nodecore/v1alpha1/solver_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/solver_webhook.go
+++ b/apis/nodecore/v1alpha1/solver_webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/nodecore/v1alpha1/vm_flavor.go
+++ b/apis/nodecore/v1alpha1/vm_flavor.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/reservation/v1alpha1/contract_types.go
+++ b/apis/reservation/v1alpha1/contract_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/reservation/v1alpha1/contract_webhook.go
+++ b/apis/reservation/v1alpha1/contract_webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/reservation/v1alpha1/groupversion_info.go
+++ b/apis/reservation/v1alpha1/groupversion_info.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/reservation/v1alpha1/reservation_status.go
+++ b/apis/reservation/v1alpha1/reservation_status.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/reservation/v1alpha1/reservation_types.go
+++ b/apis/reservation/v1alpha1/reservation_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/reservation/v1alpha1/reservation_webhook.go
+++ b/apis/reservation/v1alpha1/reservation_webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/reservation/v1alpha1/transaction_types.go
+++ b/apis/reservation/v1alpha1/transaction_types.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/reservation/v1alpha1/transaction_webhook.go
+++ b/apis/reservation/v1alpha1/transaction_webhook.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/local-resource-manager/doc.go
+++ b/cmd/local-resource-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/local-resource-manager/main.go
+++ b/cmd/local-resource-manager/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/network-manager/doc.go
+++ b/cmd/network-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/network-manager/main.go
+++ b/cmd/network-manager/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/rear-controller/doc.go
+++ b/cmd/rear-controller/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/rear-controller/main.go
+++ b/cmd/rear-controller/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/rear-manager/doc.go
+++ b/cmd/rear-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/rear-manager/main.go
+++ b/cmd/rear-manager/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluidos-project/node //node
 
-go 1.21.0
+go 1.24.0
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/pkg/local-resource-manager/doc.go
+++ b/pkg/local-resource-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/local-resource-manager/node_controller.go
+++ b/pkg/local-resource-manager/node_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/local-resource-manager/node_services.go
+++ b/pkg/local-resource-manager/node_services.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/local-resource-manager/serviceblueprint_controller.go
+++ b/pkg/local-resource-manager/serviceblueprint_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/network-manager/doc.go
+++ b/pkg/network-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/contract-manager/doc.go
+++ b/pkg/rear-controller/contract-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/contract-manager/models.go
+++ b/pkg/rear-controller/contract-manager/models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/contract-manager/reservation_controller.go
+++ b/pkg/rear-controller/contract-manager/reservation_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/discovery-manager/discovery_controller.go
+++ b/pkg/rear-controller/discovery-manager/discovery_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/discovery-manager/doc.go
+++ b/pkg/rear-controller/discovery-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/discovery-manager/peeringcandidate_wh.go
+++ b/pkg/rear-controller/discovery-manager/peeringcandidate_wh.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,7 +114,6 @@ func (v *PCValidator) HandleUpdate(_ context.Context, req admission.Request) adm
 		return admission.Denied("Peering candidate can be updated if Available flag is changed from false to true")
 	}
 
-	//nolint:lll // This is a long line
 	return admission.Allowed("")
 }
 

--- a/pkg/rear-controller/doc.go
+++ b/pkg/rear-controller/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/gateway/client.go
+++ b/pkg/rear-controller/gateway/client.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/gateway/doc.go
+++ b/pkg/rear-controller/gateway/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/gateway/gateway.go
+++ b/pkg/rear-controller/gateway/gateway.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/gateway/provider.go
+++ b/pkg/rear-controller/gateway/provider.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/gateway/routes.go
+++ b/pkg/rear-controller/gateway/routes.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/gateway/services.go
+++ b/pkg/rear-controller/gateway/services.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/gateway/utils.go
+++ b/pkg/rear-controller/gateway/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/grpc/doc.go
+++ b/pkg/rear-controller/grpc/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/grpc/liqo-resource-manager.go
+++ b/pkg/rear-controller/grpc/liqo-resource-manager.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-controller/grpc/service.go
+++ b/pkg/rear-controller/grpc/service.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-manager/allocation_controller.go
+++ b/pkg/rear-manager/allocation_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-manager/allocation_wh.go
+++ b/pkg/rear-manager/allocation_wh.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-manager/doc.go
+++ b/pkg/rear-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/rear-manager/solver_controller.go
+++ b/pkg/rear-manager/solver_controller.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -223,6 +223,7 @@ func checkInitialStatus(solver *nodecorev1alpha1.Solver) bool {
 	return false
 }
 
+//nolint:unparam // result is required by the function
 func (r *SolverReconciler) handleFindCandidate(ctx context.Context, req ctrl.Request, solver *nodecorev1alpha1.Solver) (ctrl.Result, error) {
 	findCandidateStatus := solver.Status.FindCandidate
 	switch findCandidateStatus {
@@ -349,6 +350,7 @@ func (r *SolverReconciler) getContractByPeeringCandidate(ctx context.Context, pc
 	return contract, nil
 }
 
+//nolint:unparam // result is required by the function
 func (r *SolverReconciler) handleReserveAndBuy(ctx context.Context, req ctrl.Request, solver *nodecorev1alpha1.Solver) (ctrl.Result, error) {
 	reserveAndBuyStatus := solver.Status.ReserveAndBuy
 	switch reserveAndBuyStatus {
@@ -559,6 +561,7 @@ func contains(slice []string, s string) bool {
 	return false
 }
 
+//nolint:unparam // result is required by the function
 func (r *SolverReconciler) handlePeering(
 	ctx context.Context,
 	req ctrl.Request,

--- a/pkg/utils/common/common.go
+++ b/pkg/utils/common/common.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/common/doc.go
+++ b/pkg/utils/common/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/consts/doc.go
+++ b/pkg/utils/consts/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/flags/doc.go
+++ b/pkg/utils/flags/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/flags/flags.go
+++ b/pkg/utils/flags/flags.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/getters/doc.go
+++ b/pkg/utils/getters/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/getters/getters.go
+++ b/pkg/utils/getters/getters.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/doc.go
+++ b/pkg/utils/models/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/filters.go
+++ b/pkg/utils/models/filters.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/flavor-k8slice-configuration-models.go
+++ b/pkg/utils/models/flavor-k8slice-configuration-models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/flavor-k8slice-models.go
+++ b/pkg/utils/models/flavor-k8slice-models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/flavor-sensor-models.go
+++ b/pkg/utils/models/flavor-sensor-models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/flavor-service-configuration-models.go
+++ b/pkg/utils/models/flavor-service-configuration-models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/flavor-service-models.go
+++ b/pkg/utils/models/flavor-service-models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/flavor-vm-models.go
+++ b/pkg/utils/models/flavor-vm-models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/gateway.go
+++ b/pkg/utils/models/gateway.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/local-resource-manager.go
+++ b/pkg/utils/models/local-resource-manager.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/models.go
+++ b/pkg/utils/models/models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/network-identity-models.go
+++ b/pkg/utils/models/network-identity-models.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/models/reservation.go
+++ b/pkg/utils/models/reservation.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/namings/doc.go
+++ b/pkg/utils/namings/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/namings/namings.go
+++ b/pkg/utils/namings/namings.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/parseutil/doc.go
+++ b/pkg/utils/parseutil/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/parseutil/parseutil.go
+++ b/pkg/utils/parseutil/parseutil.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/resourceforge/doc.go
+++ b/pkg/utils/resourceforge/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/resourceforge/forge.go
+++ b/pkg/utils/resourceforge/forge.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/services/doc.go
+++ b/pkg/utils/services/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/services/flavours_services.go
+++ b/pkg/utils/services/flavours_services.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/tools/doc.go
+++ b/pkg/utils/tools/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/tools/tools.go
+++ b/pkg/utils/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/virtual-fabric-manager/doc.go
+++ b/pkg/virtual-fabric-manager/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/virtual-fabric-manager/services.go
+++ b/pkg/virtual-fabric-manager/services.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 FLUIDOS Project
+// Copyright 2022-2025 FLUIDOS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hi!

This PR is intended to upgrade the CI pipeline of GitHub to Go version 1.24 and golangci-lint to version 1.64.2

This change is necessary for further upgrades both in node code and its dependencies.

List of changes:
- Changed copyright year from 2024 to 2025 for files in folder apis/, cmd/ and pkg (but not the zz-deepcopy ones in apis/)
- Minor Changes on golangci.yml (deprecated settings and max limit)

Thank you!

Riccardo