### PR TITLE
Fix misalignment in PodNamespaceSelector representation

### DIFF
--- a/apis/nodecore/v1alpha1/network_intent.go
+++ b/apis/nodecore/v1alpha1/network_intent.go
@@ -52,8 +52,8 @@ type ResourceSelector struct {
 
 // SourceDestination can represent either the source or destination of a network intent.
 type SourceDestination struct {
-	// IsHotCluster is true if the source/destination is a hot cluster.
-	IsHotCluster bool `json:"isHotCluster"`
+	// IsHostCluster is true if the source/destination is a hot cluster.
+	IsHostCluster bool `json:"isHostCluster"`
 	// ResourceSelector is the resource selector of the source/destination.
 	ResourceSelector ResourceSelector `json:"resourceSelector"`
 }

--- a/pkg/utils/models/network-identity-models.go
+++ b/pkg/utils/models/network-identity-models.go
@@ -43,7 +43,7 @@ type NetworkAuthorizations struct {
 
 // SourceDestination represents the source or destination of a network intent.
 type SourceDestination struct {
-	IsHotCluster     bool             `json:"isHotCluster"`
+	IsHostCluster    bool             `json:"isHostCluster"`
 	ResourceSelector ResourceSelector `json:"resourceSelectors"`
 }
 

--- a/pkg/utils/models/network-identity-models.go
+++ b/pkg/utils/models/network-identity-models.go
@@ -58,11 +58,6 @@ type CIDRSelector string
 
 // PodNamespaceSelector represents the pod namespace selector of a SourceDestination.
 type PodNamespaceSelector struct {
-	Pod       []keyValuePair `json:"pod"`
-	Namespace []keyValuePair `json:"namespace"`
-}
-
-type keyValuePair struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Pod       map[string]string `json:"pod"`
+	Namespace map[string]string `json:"namespace"`
 }

--- a/pkg/utils/parseutil/parseutil.go
+++ b/pkg/utils/parseutil/parseutil.go
@@ -489,7 +489,7 @@ func ParseSourceDestination(sourceDestination nodecorev1alpha1.SourceDestination
 			return nil, err
 		}
 		resourceSelector = models.ResourceSelector{
-			TypeIdentifier: models.CIDRSelectorType,
+			TypeIdentifier: models.PodNamespaceSelectorType,
 			Selector:       podNamespaceSelectorData,
 		}
 	default:

--- a/pkg/utils/parseutil/parseutil.go
+++ b/pkg/utils/parseutil/parseutil.go
@@ -496,7 +496,7 @@ func ParseSourceDestination(sourceDestination nodecorev1alpha1.SourceDestination
 		return nil, fmt.Errorf("unknown resource selector type")
 	}
 	sourceDestinationModel := models.SourceDestination{
-		IsHotCluster:     sourceDestination.IsHotCluster,
+		IsHostCluster:    sourceDestination.IsHostCluster,
 		ResourceSelector: resourceSelector,
 	}
 

--- a/pkg/utils/resourceforge/forge.go
+++ b/pkg/utils/resourceforge/forge.go
@@ -794,7 +794,7 @@ func ForgeSourceDestinationFromObj(sourceDestination *models.SourceDestination) 
 		return nil
 	}
 	return &nodecorev1alpha1.SourceDestination{
-		IsHotCluster:     sourceDestination.IsHotCluster,
+		IsHostCluster:    sourceDestination.IsHostCluster,
 		ResourceSelector: *resourceSelector,
 	}
 }

--- a/pkg/utils/resourceforge/forge.go
+++ b/pkg/utils/resourceforge/forge.go
@@ -766,24 +766,8 @@ func ForgeResourceSelectorFromObj(resourceSelector *models.ResourceSelector) *no
 		}
 		// Create PodNamespaceSelector nodecorev1alpha1
 		podNamespaceSelectorCR := nodecorev1alpha1.PodNamespaceSelector{
-			// Copy map of models.PodNamespaceSelector.Pod to nodecorev1alpha1.PodNamespaceSelector.Pod
-			Pod: func() map[string]string {
-				podMap := make(map[string]string)
-				for i := range resourceSelectorStruct.Pod {
-					keyValuePair := resourceSelectorStruct.Pod[i]
-					podMap[keyValuePair.Key] = keyValuePair.Value
-				}
-				return podMap
-			}(),
-			// Copy map of models.PodNamespaceSelector.Namespace to nodecorev1alpha1.PodNamespaceSelector.Namespace
-			Namespace: func() map[string]string {
-				namespaceMap := make(map[string]string)
-				for i := range resourceSelectorStruct.Namespace {
-					keyValuePair := resourceSelectorStruct.Namespace[i]
-					namespaceMap[keyValuePair.Key] = keyValuePair.Value
-				}
-				return namespaceMap
-			}(),
+			Pod:       resourceSelectorStruct.Pod,
+			Namespace: resourceSelectorStruct.Namespace,
 		}
 		// Marshal PodNamespaceSelector to JSON
 		resourceSelectorData, err := json.Marshal(podNamespaceSelectorCR)


### PR DESCRIPTION
Hello everyone,

This pull request addresses a parsing error in the REAR Controller caused by a misalignment between the internal and CRD representations of the `PodNamespaceSelector`.  

The issue arises when the providers' Flavor resources include a non-empty value for the `networkAuthorizations` field, which is used for the intent-based border protection solution developed in WP5.  In such cases, when a consumer retrieves the available resources as PeeringCandidates, a parsing error occurs in the consumer's REAR Controller, resulting in a null value for the `networkAuthorizations` field. The following reports the log entries illustrating the error:
```
E0527 14:30:47.059078       1 forge.go:809] Error when parsing resource selector from source destination
E0527 14:30:47.059085       1 forge.go:823] Error when parsing source from network intent
E0527 14:30:47.059100       1 forge.go:850] Error when parsing denied communication from network authorizations
```

To resolve the problem, the proposed PR aligns the two distinct representations in favor of a unified one,  simplifying mapping operations and eliminating the parsing error.

Thanks,
Francesco  